### PR TITLE
Correct version in plugin.yml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 targetCompatibility = 1.8
 sourceCompatibility = 1.8
+version = '1.4.3'
 repositories {
 	mavenCentral()
 	maven {
@@ -44,4 +45,8 @@ sourceSets {
 			srcDir 'res'
 		}
 	}
+}
+processResources {
+    outputs.upToDateWhen { false }
+    expand 'pluginVersion': project.version
 }

--- a/res/plugin.yml
+++ b/res/plugin.yml
@@ -1,6 +1,6 @@
 name: PlugWoman
 main: redempt.plugwoman.PlugWoman
-version: 1.0
+version: ${pluginVersion}
 depend: []
 author: Redempt
 api-version: 1.13


### PR DESCRIPTION
Makes it so that the version isn't always 1.0

Noticed this in your other plugins too, so you can close this PR if you'd like

Although for public plugins (and private plugins), I'd suggest putting the version in the `plugin.yml` (and this PR also changes the built file name to `PlugWoman-1.4.3.jar` since that's how Gradle manages file names by default) to let users know what version they are on